### PR TITLE
Define a constructor name

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ module.exports = Web3ProviderEngine
 
 inherits(Web3ProviderEngine, EventEmitter)
 
+// fix for web3.js
+Object.defineProperty(Web3ProviderEngine, 'name', { value: 'HttpProvider' })
+
 function Web3ProviderEngine(opts) {
   const self = this
   EventEmitter.call(self)


### PR DESCRIPTION
Since web3.js beta.38, there is validation on the provided provider.
This fix will allow the use of `provider-engine`.

See the validation here:
https://github.com/ethereum/web3.js/blob/1.0/packages/web3-providers/src/resolvers/ProviderResolver.js